### PR TITLE
Avoided a symbol conflict when generating the parser for JavaScript, …

### DIFF
--- a/spec/2018Sep/fhirpath.g4
+++ b/spec/2018Sep/fhirpath.g4
@@ -46,13 +46,13 @@ externalConstant
 
 invocation                          // Terms that can be used after the function/member invocation '.'
         : identifier                                            #memberInvocation
-        | function                                              #functionInvocation
+        | functn                                                #functionInvocation
         | '$this'                                               #thisInvocation
         | '$index'                                              #indexInvocation
         | '$total'                                              #totalInvocation
         ;
 
-function
+functn
         : identifier '(' paramList? ')'
         ;
 


### PR DESCRIPTION
…in which the word function is a keyword.

Without this change, attempting generate the parser from the grammar file results in the following errors:

java -Xmx500M -cp "../../antlr-4.7.1-complete.jar:$CLASSPATH" org.antlr.v4.Tool -o generated -Dlanguage=JavaScript fhirpath.g4

error(134): fhirpath.g4:55:0: symbol function conflicts with generated code in target language or runtime
error(134): fhirpath.g4:49:10: symbol function conflicts with generated code in target language or runtime
