### PR TITLE
Update ANSI approval based on reaffirmation ballot

### DIFF
--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -14,8 +14,8 @@ Version: 2.0.0 Public Domain ([Creative Commons 0](http://creativecommons.org/pu
 
 | Formal Name: | HL7 Cross-Paradigm Specification: FHIRPath, Release 1 |
 | = | = |
-| ANSI Designation: | ANSI/HL7 NMN R1-2020 |
-| Date of Approval: | 2020-01-16 |
+| ANSI Designation: | ANSI/HL7 FHIRPath R1-2020 (R2024) |
+| Date of Approval: | 2024-07-24 |
 {: .colsi style="width: unset;"}
 
 FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions of this specification marked Normative have met its requirements for development of a formal standard.


### PR DESCRIPTION
Updated the details of the ANSI approval on the index page based on the May 2024 reaffirmation ballot [Ballot Desktop link](https://www.hl7.org/BallotDesktop/index.cfm?view=tallydetail&ballotid=2314)