### PR TITLE
Bp normative 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ qa/
 temp/
 template/
 input-cache/
+template-fhirpath/**/.index.db
+template-fhirpath/**/.index.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+    "cSpell.words": [
+        "abfg",
+        "CIMI",
+        "colsi",
+        "datetimes",
+        "defg",
+        "definevariable",
+        "Gert",
+        "LOINC",
+        "metamodel",
+        "modelinfo",
+        "PCRE",
+        "Subsetting",
+        "trialuse",
+        "UCUM",
+        "unescapes",
+        "unionother",
+        "urlbase",
+        "Wouter",
+        "xaxbxcx",
+        "XMLRE"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Fluent Path Specification - this is the source for the HL7 Fluent path specifica
 ## Notes to editors on Markdown
 * Watch for edits on | chars in the content,<br/> if they are not in a code block `code | block` then they will need to be delimited i.e. the format **YYYY-MM-DDThh:mm:ss.fff(+\|-)hh:mm**)
 * Some helpful markdown editing tips can be found here https://kramdown.gettalong.org/quickref.html#links-and-images
+
+## Testing the ANTLR4 grammar
+You can use the online tool to test the grammar.
+http://lab.antlr.org/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Fluent Path Specification - this is the source for the HL7 Fluent path specification, as published at http://hl7.org/fhirpath
 
+Looking for implementations?<br/>
+See [FHIRPath Implementations on the HL7 confluence](https://confluence.hl7.org/display/FHIRI/FHIRPath+Implementations)
 
 ## Notes to editors on Markdown
 * Watch for edits on | chars in the content,<br/> if they are not in a code block `code | block` then they will need to be delimited i.e. the format **YYYY-MM-DDThh:mm:ss.fff(+\|-)hh:mm**)

--- a/input/pages/grammar.md
+++ b/input/pages/grammar.md
@@ -10,6 +10,6 @@ This page contains the [Antlr 4.0](http://www.antlr.org/) grammar for FHIRPath.
 
 [Raw FHIRPath grammar](fhirpath.g4)
 
-<pre>
+``` antlr4
 {% include_relative fhirpath.g4 %}
-</pre>
+```

--- a/input/pages/grammar.md
+++ b/input/pages/grammar.md
@@ -13,3 +13,4 @@ This page contains the [Antlr 4.0](http://www.antlr.org/) grammar for FHIRPath.
 ``` antlr4
 {% include_relative fhirpath.g4 %}
 ```
+{: tabIndex }

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -94,8 +94,8 @@ This specification uses the conformance verbs SHALL, MUST, SHOULD, and MAY as de
 
 * SHALL/MUST: An absolute requirement for all implementations
 * SHALL/MUST NOT: An absolute prohibition against inclusion for all implementations
-* SHOULD/SHOULD NOT: A best practice or recommendation to be considered by implementers within the context of their particular implementation; there may be valid resons to ignore an item, but the full implications must be understood and carefully weighed before choosing a different course
-* MAY: This is truly optional language for an implementation; can be inluced or omitted as the implementer decides with no implications.
+* SHOULD/SHOULD NOT: A best practice or recommendation to be considered by implementers within the context of their particular implementation; there may be valid reasons to ignore an item, but the full implications must be understood and carefully weighed before choosing a different course
+* MAY: This is truly optional language for an implementation; can be included or omitted as the implementer decides with no implications.
 
 ## Navigation model
 
@@ -487,7 +487,7 @@ Patient.active and Patient.gender and Patient.telecom
 
 Assuming the `Patient` instance has an `active` value of `true`, a `gender` of `female` and a single `telecom` element, this expression will result in true. However, consider a different instance of `Patient` that has an `active` value of `true`, a `gender` of `male`, and multiple `telecom` elements, then this expression will result in an error because of the multiple telecom elements.
 
-Note that for repeating elements like `telecom` in the above example, the logic _looks_ like an existence check. To avoid confusion and reduce unintended errors, authors should use the explicit form of these checks when appropriate. For example, a more explicit rendering of the same logic that more clearly indicates the actual intent and avoids the run-time rror is:
+Note that for repeating elements like `telecom` in the above example, the logic _looks_ like an existence check. To avoid confusion and reduce unintended errors, authors should use the explicit form of these checks when appropriate. For example, a more explicit rendering of the same logic that more clearly indicates the actual intent and avoids the run-time error is:
 
 ``` fhirpath
 Patient.active and Patient.gender and Patient.telecom.count() = 1
@@ -538,7 +538,7 @@ The first example returns `true` if the `Patient` has any `name` elements.
 
 The second example returns `true` if the `Patient` has any `identifier` elements that have a `use` element equal to `'official'`.
 
-The third example retruns `true` if the `Patient` has any `telecom` elements that have a `system` element equal to `'phone'` and a `use` element equal to `'mobile'`.
+The third example returns `true` if the `Patient` has any `telecom` elements that have a `system` element equal to `'phone'` and a `use` element equal to `'mobile'`.
 
 And finally, the fourth example returns `true` if the `Patient` has any `generalPractitioner` elements of type `Practitioner`.
 
@@ -2504,7 +2504,7 @@ The implies operator is useful for testing conditionals. For example, if a given
 ``` fhirpath
 Patient.name.given.exists() implies Patient.name.family.exists()
 CareTeam.onBehalfOf.exists() implies (CareTeam.member.resolve() is Practitioner)
-StructrureDefinition.contextInvariant.exists() implies StructureDefinition.type = 'Extension'
+StructureDefinition.contextInvariant.exists() implies StructureDefinition.type = 'Extension'
 ```
 
 Note that implies may use short-circuit evaluation in the case that the first operand evaluates to false.
@@ -3028,7 +3028,7 @@ Results in:
 #### Anonymous Types
 {:.stu}
 
-Anonymous types are structured types that have no associated name, only the elements of the structre. For example, in FHIR, the `Patient.contact` element has multiple sub-elements, but is not explicitly named. For types such as this, the result is a `TupleTypeInfo`:
+Anonymous types are structured types that have no associated name, only the elements of the structure. For example, in FHIR, the `Patient.contact` element has multiple sub-elements, but is not explicitly named. For types such as this, the result is a `TupleTypeInfo`:
 {:.stu}
 
 ``` typescript
@@ -3177,7 +3177,7 @@ text/fhirpath
 ## Use of FHIRPath on HL7 Version 2 messages
 {: .appendix }
 
-FHIRPath can be used against HL7 V2 messages. This UML diagram summarises the
+FHIRPath can be used against HL7 V2 messages. This UML diagram summarizes the
 Object Model on which the FHIRPath statements are written:
 
 ![Class Model for HL7 V2](v2-class-model.png){: height="456",width="760"}
@@ -3207,7 +3207,7 @@ Get the value of the first component in the first repeat of PID-3
 Message.segment[2].elements(3).simple()
 ```
 
-Get a collection  with is the string values of all the repeats in the the 3rd element of the 2nd segement. Typically, this assumes that there is no repeats, and so this is a simple value
+Get a collection  with is the string values of all the repeats in the the 3rd element of the 2nd segment. Typically, this assumes that there is no repeats, and so this is a simple value
 
 ``` fhirpath
 Message.segment.where(code = 'PID').field[3].element.where(component[4].value = 'MR').simple()

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -8,25 +8,19 @@ FHIRPath is a path based navigation and extraction language, somewhat like XPath
 
 Looking for implementations? See [FHIRPath Implementations on the HL7 confluence](https://confluence.hl7.org/display/FHIRI/FHIRPath+Implementations){:target="_blank"}
 
-> **Note:** The following sections of this specification are proposed to be updated to normative in the next release:
-> 
-> * [Functions - String (trim, split, join)](#trim--string)
-> * [Functions - Math (except for round)](#math)
-> * [Functions - Utility (precision)](#precision--integer)
-> * [Aggregates](#aggregates)
->
-> ***Note:*** *The green markings are for highlight only during ballot, they will be removed when the balloted content is approved as normative. The stu markings will remain*
-{: .stu-note.normative }
 
 > **Note:** The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):
 > 
+> * [Aggregates](#aggregates)
 > * [Literals - Long](#long)
 > * [Conversions - toLong](#tolong--long)
 > * [Functions - String (lastIndexOf)](#lastindexofsubstring--string--integer)
 > * [Functions - String (matchesFull)](#matchesfullregex--string--boolean)
+> * [Functions - String (trim, split, join)](#trim--string)
 > * [Functions - String (encode, decode, escape, unescape)](#additional-string-functions)
-> * [Functions - Math (round - due to edge cases)](#roundprecision--integer--decimal)
+> * [Functions - Math](#math)
 > * [Functions - Utility (defineVariable, lowBoundary, highBoundary)](#definevariable)
+> * [Functions - Utility (precision)](#precision--integer)
 > * [Functions - Extract Date/DateTime/Time components](#extract-datedatetimetime-components)
 > * [Types - Reflection](#reflection)
 > 
@@ -1530,224 +1524,223 @@ If no target is specified, the result is empty.
 {:.stu}
 
 #### trim() : String
-> **Note:** the contents of this section are proposed to be updated to normative in the next release
-{: .stu-note.normative }
+{: .stu }
 
 The trim function trims whitespace characters from the beginning and ending of the input string, with whitespace characters as defined in the [Whitespace](#whitespace) lexical category.
-{:.stu.normative}
+{:.stu}
 
 If the input is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 #### split(separator: String) : collection
-{:.stu.normative}
+{:.stu}
 
 The split function splits a singleton input string into a list of strings, using the given separator.
-{:.stu.normative}
+{:.stu}
 
 If the input is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input string does not contain any appearances of the separator, the result is the input string.
-{:.stu.normative}
+{:.stu}
 
 The following example illustrates the behavior of the `.split` operator:
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 ('A,B,C').split(',') // { 'A', 'B', 'C' }
 ('ABC').split(',') // { 'ABC' }
 'A,,C'.split(',') // { 'A', '', 'C' }
 ```
-{:.stu.normative}
+{:.stu}
 
 #### join([separator: String]) : String
-{:.stu.normative}
+{:.stu}
 
 The join function takes a collection of strings and _joins_ them into a single string, optionally using the given separator.
-{:.stu.normative}
+{:.stu}
 
 If the input is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If no separator is specified, the strings are directly concatenated.
-{:.stu.normative}
+{:.stu}
 
 The following example illustrates the behavior of the `.join` operator:
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 ('A' | 'B' | 'C').join() // 'ABC'
 ('A' | 'B' | 'C').join(',') // 'A,B,C'
 ```
-{:.stu.normative}
+{:.stu}
 
 ### Math
 
-> **Note:** the contents of this section are proposed to be updated to normative in the next release
-{: .stu-note.normative }
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
 
 The functions in this section operate on collections with a single item. Unless otherwise noted, if there is more than one item, or the item is not compatible with the expected type, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 Note also that although all functions return collections, if a given function is defined to return a single element, the return type in the description of the function is simplified to just the type of the single element, rather than the list type.
-{:.stu.normative}
+{:.stu}
 
 The math functions in this section enable FHIRPath to be used not only for path selection, but for providing a platform-independent representation of calculation logic in artifacts such as questionnaires and documentation templates. For example:
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 (%weight/(%height.power(2))).round(1)
 ```
-{:.stu.normative}
+{:.stu}
 
 This example from a questionnaire calculates the Body Mass Index (BMI) based on the responses to the weight and height elements. For more information on the use of FHIRPath in questionnaires, see the [Structured Data Capture](http://hl7.org/fhir/uv/sdc/) (SDC) implementation guide.
-{:.stu.normative}
+{:.stu}
 
 #### abs() : Integer | Decimal | Quantity
-{:.stu.normative}
+{:.stu}
 
 Returns the absolute value of the input. When taking the absolute value of a quantity, the unit is unchanged.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 (-5).abs() // 5
 (-5.5).abs() // 5.5
 (-5.5 'mg').abs() // 5.5 'mg'
 ```
-{:.stu.normative}
+{:.stu}
 
 #### ceiling() : Integer
-{:.stu.normative}
+{:.stu}
 
 Returns the first integer greater than or equal to the input.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 1.ceiling() // 1
 1.1.ceiling() // 2
 (-1.1).ceiling() // -1
 ```
-{:.stu.normative}
+{:.stu}
 
 #### exp() : Decimal
-{:.stu.normative}
+{:.stu}
 
 Returns _e_ raised to the power of the input.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains an Integer, it will be implicitly converted to a Decimal and the result will be a Decimal.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 0.exp() // 1.0
 (-0.0).exp() // 1.0
 ```
-{:.stu.normative}
+{:.stu}
 
 #### floor() : Integer
-{:.stu.normative}
+{:.stu}
 
 Returns the first integer less than or equal to the input.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 1.floor() // 1
 2.1.floor() // 2
 (-2.1).floor() // -3
 ```
-{:.stu.normative}
+{:.stu}
 
 #### ln() : Decimal
-{:.stu.normative}
+{:.stu}
 
 Returns the natural logarithm of the input (i.e. the logarithm base _e_).
-{:.stu.normative}
+{:.stu}
 
 When used with an Integer, it will be implicitly converted to a Decimal.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 1.ln() // 0.0
 1.0.ln() // 0.0
 ```
-{:.stu.normative}
+{:.stu}
 
 #### log(base : Decimal) : Decimal
-{:.stu.normative}
+{:.stu}
 
 Returns the logarithm base `base` of the input number.
-{:.stu.normative}
+{:.stu}
 
 When used with Integers, the arguments will be implicitly converted to Decimal.
-{:.stu.normative}
+{:.stu}
 
 If `base` is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 16.log(2) // 4.0
 100.0.log(10.0) // 2.0
 ```
-{:.stu.normative}
+{:.stu}
 
 #### power(exponent : Integer | Decimal) : Integer | Decimal
-{:.stu.normative}
+{:.stu}
 
 Raises a number to the `exponent` power. If this function is used with Integers, the result is an Integer. If the function is used with Decimals, the result is a Decimal. If the function is used with a mixture of Integer and Decimal, the Integer is implicitly converted to a Decimal and the result is a Decimal.
-{:.stu.normative}
+{:.stu}
 
 If the power cannot be represented (such as the -1 raised to the 0.5), the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input is empty, or exponent is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 2.power(3) // 8
 2.5.power(2) // 6.25
 (-1).power(0.5) // empty ({ })
 ```
-{:.stu.normative}
+{:.stu}
 
 #### round([precision : Integer]) : Decimal
 
@@ -1779,48 +1772,48 @@ If the input collection contains multiple items, the evaluation of the expressio
 
 #### sqrt() : Decimal
 
-> **Note:** the contents of this section are proposed to be updated to normative in the next release
-{: .stu-note.normative }
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
 
 Returns the square root of the input number as a Decimal.
-{:.stu.normative}
+{:.stu}
 
 If the square root cannot be represented (such as the square root of -1), the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 81.sqrt() // 9.0
 (-1).sqrt() // empty
 ```
-{:.stu.normative}
+{:.stu}
 
 #### truncate() : Integer
-{:.stu.normative}
+{:.stu}
 
 Returns the integer portion of the input.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 101.truncate() // 101
 1.00000001.truncate() // 1
 (-1.56).truncate() // -1
 ```
-{:.stu.normative}
+{:.stu}
 
 ### Tree navigation
 
@@ -1959,32 +1952,30 @@ If the input collection contains multiple items, the evaluation of the expressio
 {:.stu}
 
 #### precision() : Integer
-
-> **Note:** the contents of this section are proposed to be updated to normative in the next release
-{: .stu-note.normative }
+{:.stu}
 
 If the input collection contains a single item, this function will return the number of digits of precision.
-{:.stu.normative}
+{:.stu}
 
 The function can only be used with Decimal, Date, DateTime, and Time values.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 For Decimal values, the function returns the number of digits of precision after the decimal place in the input value.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 1.58700.precision() // 5
 ```
-{:.stu.normative}
+{:.stu}
 
 For Date and DateTime values, the function returns the number of digits of precision in the input value.
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 @2014.precision() // 4
@@ -1992,11 +1983,10 @@ For Date and DateTime values, the function returns the number of digits of preci
 @T10:30.precision() // 4
 @T10:30:00.000.precision() // 9
 ```
-{:.stu.normative}
+{:.stu}
 
 #### Extract Date/DateTime/Time components
-> **Note:** The contents of this section are Standard for Trial Use (STU)
-{: .stu-note }
+{:.stu}
 
 ##### yearOf(): Integer
 {:.stu}
@@ -2787,44 +2777,44 @@ Use parentheses to ensure the unary negation applies to the `7`:
 
 ## Aggregates
 
-> **Note:** the contents of this section are proposed to be updated to normative in the next release
-{: .stu-note.normative }
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
 
 FHIRPath supports a general-purpose aggregate function to enable the calculation of aggregates such as sum, min, and max to be expressed:
-{:.stu.normative}
+{:.stu}
 
 ### aggregate(aggregator : expression [, init : value]) : value
-{:.stu.normative}
+{:.stu}
 Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Within this expression, the standard iteration variables of `$this` and `$index` can be accessed, but also a `$total` aggregation variable.
-{:.stu.normative}
+{:.stu}
 
 The value of the `$total` variable is set to `init`, or empty (`{ }`) if no `init` value is supplied, and is set to the result of the aggregator expression after every iteration.<br/>
 The result of the aggregate function is the value of `$total` after the last iteration.
-{:.stu.normative}
+{:.stu}
 
 Using this function, sum can be expressed as:
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 value.aggregate($this + $total, 0)
 ```
-{:.stu.normative}
+{:.stu}
 
 Min can be expressed as:
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 value.aggregate(iif($total.empty(), $this, iif($this < $total, $this, $total)))
 ```
-{:.stu.normative}
+{:.stu}
 
 and average would be expressed as:
-{:.stu.normative}
+{:.stu}
 
 ``` fhirpath
 value.aggregate($total + $this, 0) / value.count()
 ```
-{:.stu.normative}
+{:.stu}
 
 ## Lexical Elements
 FHIRPath defines the following lexical elements:

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -730,7 +730,7 @@ In the above example, the symbol `Patient` must be treated as a type identifier 
 
 The indexer operation returns a collection with only the `index`-th item (0-based index). If the input collection is empty (`{ }`), or the index lies outside the boundaries of the input collection, an empty collection is returned.
 
-> Note: Unless specified otherwise by the underlying Object Model, the first item in a collection has index 0. Note that if the underlying model specifies that a collection is 1-based (the only reasonable alternative to 0-based collections), _any collections generated from operations on the 1-based list are 0-based_.
+> **Note:** Unless specified otherwise by the underlying Object Model, the first item in a collection has index 0. Note that if the underlying model specifies that a collection is 1-based (the only reasonable alternative to 0-based collections), _any collections generated from operations on the 1-based list are 0-based_.
 
 The following example returns the element in the `name` collection of the Patient with index 0:
 
@@ -1317,7 +1317,7 @@ If the input collection contains multiple items, the evaluation of the expressio
 'abc'.contains('d') // false
 ```
 
-> Note: The `.contains()` function described here is a string function that looks for a substring in a string. This is different than the `contains` operator, which is a list operator that looks for an element in a list.
+> **Note:** The `.contains()` function described here is a string function that looks for a substring in a string. This is different than the `contains` operator, which is a list operator that looks for an element in a list.
 
 #### upper() : String
 
@@ -1389,7 +1389,7 @@ This example of `replaceMatches()` will convert a string with a date formatted a
        '${day}-${month}-${year}')
 ```
 
-> Note: Platforms will typically use native regular expression implementations. These are typically fairly similar, but there will always be small differences. As such, FHIRPath does not prescribe a particular dialect, but recommends the use of the [\[PCRE\]](#PCRE) flavor as the dialect most likely to be broadly supported and understood.
+> **Note:** Platforms will typically use native regular expression implementations. These are typically fairly similar, but there will always be small differences. As such, FHIRPath does not prescribe a particular dialect, but recommends the use of the [\[PCRE\]](#PCRE) flavor as the dialect most likely to be broadly supported and understood.
 
 #### length() : Integer
 
@@ -1409,7 +1409,7 @@ If the input collection contains multiple items, the evaluation of the expressio
 
 ### Additional String Functions
 
-> Note: the contents of this section are Standard for Trial Use (STU)
+> **Note:** The contents of this section are Standard for Trial Use (STU)
 {: .stu-note }
 
 #### encode(format : String) : String
@@ -1772,7 +1772,7 @@ Returns a collection with all immediate child nodes of all items in the input co
 
 Returns a collection with all descendant nodes of all items in the input collection. The result does not include the nodes in the input collection themselves. This function is a shorthand for `repeat(children())`. Note that the ordering of the children is undefined and using functions like `first()` on the result may return different results on different platforms.
 
-> Note: Many of these functions will result in a set of nodes of different underlying types. It may be necessary to use `ofType()` as described in the previous section to maintain type safety. See [Type safety and strict evaluation](#type-safety-and-strict-evaluation) for more information about type safe use of FHIRPath expressions.
+> **Note:** Many of these functions will result in a set of nodes of different underlying types. It may be necessary to use `ofType()` as described in the previous section to maintain type safety. See [Type safety and strict evaluation](#type-safety-and-strict-evaluation) for more information about type safe use of FHIRPath expressions.
 
 ### Utility functions
 
@@ -1808,7 +1808,7 @@ Returns the current date.
 
 <a name="definevariable"></a>
 #### defineVariable(name: String [, expr: expression])
-> Note: The contents of this section are Standard for Trial Use (STU)
+> **Note:** The contents of this section are Standard for Trial Use (STU)
 {: .stu-note }
 
 Defines a variable named `name` that is accessible in subsequent expressions and has the value of `expr` if present, otherwise the value of the input collection. In either case the function does not change the input and the output is the same as the input collection.
@@ -1837,7 +1837,7 @@ group.select(
 ```
 {:.stu}
 
-> Note: this would be implemented using expression scoping on the variable stack and after expression completion the temporary variable would be popped off the stack.
+> **Note:** this would be implemented using expression scoping on the variable stack and after expression completion the temporary variable would be popped off the stack.
 {:.stu}
 
 #### lowBoundary([precision: Integer]): Decimal | Date | DateTime | Time
@@ -1933,7 +1933,7 @@ For Date and DateTime values, the function returns the number of digits of preci
 {:.stu}
 
 #### Extract Date/DateTime/Time components
-> Note: The contents of this section are Standard for Trial Use (STU)
+> **Note:** The contents of this section are Standard for Trial Use (STU)
 {: .stu-note }
 
 ##### yearOf(): Integer
@@ -2392,7 +2392,7 @@ The `is()` function is supported for backwards compatibility with previous imple
 Bundle.entry.resource.all($this.is(Observation) implies status = 'finished')
 ```
 
-> Note: The `is()` function is defined for backwards compatibility only and may be deprecated in a future release.
+> **Note:** The `is()` function is defined for backwards compatibility only and may be deprecated in a future release.
 
 #### as _type specifier_
 
@@ -2412,7 +2412,7 @@ The `as()` function is supported for backwards compatibility with previous imple
 Observation.component.where(value.as(Quantity) > 30 'mg')
 ```
 
-> Note: The `as()` function is defined for backwards compatibility only and may be deprecated in a future release.
+> **Note:** The `as()` function is defined for backwards compatibility only and may be deprecated in a future release.
 
 ### Collections
 
@@ -2442,7 +2442,7 @@ Patient.name.given contains 'Joe'
 ### Boolean logic
 For all boolean operators, the collections passed as operands are first evaluated as Booleans (as described in [Singleton Evaluation of Collections](#singleton-evaluation-of-collections)). The operators then use three-valued logic to propagate empty operands.
 
-> Note: To ensure that FHIRPath expressions can be freely rewritten by underlying implementations, there is no expectation that an implementation respect short-circuit evaluation. With regard to performance, implementations may use short-circuit evaluation to reduce computation, but authors should not rely on such behavior, and implementations must not change semantics with short-circuit evaluation. If short-circuit evaluation is needed to avoid effects (e.g. runtime exceptions), use the [`iif()`](#iif) function.
+> **Note:** To ensure that FHIRPath expressions can be freely rewritten by underlying implementations, there is no expectation that an implementation respect short-circuit evaluation. With regard to performance, implementations may use short-circuit evaluation to reduce computation, but authors should not rely on such behavior, and implementations must not change semantics with short-circuit evaluation. If short-circuit evaluation is needed to avoid effects (e.g. runtime exceptions), use the [`iif()`](#iif) function.
 
 #### and
 
@@ -2908,7 +2908,7 @@ Note also that these tokens are not restricted to simple types, and they may hav
 
 Attempting to access an undefined environment variable will result in an error, but accessing a defined environment variable that does not have a value specified results in empty (`{ }`).
 
-> Note: For backwards compatibility with some existing implementations, the token for an environment variable may also be a string, as in `%'us-zip'`, with no difference in semantics.
+> **Note:** For backwards compatibility with some existing implementations, the token for an environment variable may also be a string, as in `%'us-zip'`, with no difference in semantics.
 
 ## Types and Reflection
 
@@ -2924,7 +2924,7 @@ When resolving an identifier that is also the root of a FHIRPath expression, it 
 
 ### Reflection
 
-> Note: The contents of this section are Standard for Trial Use (STU)
+> **Note:** The contents of this section are Standard for Trial Use (STU)
 {: .stu-note }
 
 FHIRPath supports reflection to provide the ability for expressions to access type information describing the structure of values. The `type()` function returns the type information for each element of the input collection, using one of the following concrete subtypes of `TypeInfo`:
@@ -3063,7 +3063,7 @@ Results in:
 ```
 {:.stu}
 
-> Note: These structures are a subset of the abstract metamodel used by the [Clinical Quality Language Tooling](https://github.com/cqframework/clinical_quality_language).
+> **Note:** These structures are a subset of the abstract metamodel used by the [Clinical Quality Language Tooling](https://github.com/cqframework/clinical_quality_language).
 {:.stu}
 
 ## Type safety and strict evaluation
@@ -3146,7 +3146,7 @@ The formal syntax for FHIRPath is specified as an [Antlr 4.0](http://www.antlr.o
 
 [grammar.html](grammar.html)
 
-> Note: If there are discrepancies between this documentation and the grammar included at the above link, the grammar is considered the source of truth.
+> **Note:** If there are discrepancies between this documentation and the grammar included at the above link, the grammar is considered the source of truth.
 
 ### Model Information
 
@@ -3154,7 +3154,7 @@ The model information returned by the reflection function `type()`  is specified
 
 [modelinfo.xsd](modelinfo.xsd)
 
-> Note: The model information file included here is not a normative aspect of the FHIRPath specification. It is the same model information file used by the [Clinical Quality Framework Tooling](http://github.com/cqframework/clinical_quality_language) and is included for reference as a simple formalism that meets the requirements described in the normative [Reflection](#reflection) section above.
+> **Note:** The model information file included here is not a normative aspect of the FHIRPath specification. It is the same model information file used by the [Clinical Quality Framework Tooling](http://github.com/cqframework/clinical_quality_language) and is included for reference as a simple formalism that meets the requirements described in the normative [Reflection](#reflection) section above.
 
 As discussed in the section on case-sensitivity, each model used within FHIRPath determines whether or not identifiers in the model are case-sensitive. This information is provided as part of the model information and tooling should respect the case-sensitive settings for each model.
 
@@ -3171,7 +3171,7 @@ In addition, a media type is defined to support describing FHIRPath content:
 text/fhirpath
 ```
 
-> Note: The appendices are included for informative purposes and are not a normative part of the specification.
+> **Note:** The appendices are included for informative purposes and are not a normative part of the specification.
 
 <a name="hl7v2"></a>
 ## Use of FHIRPath on HL7 Version 2 messages

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -23,8 +23,6 @@ FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions 
 
 > **Note:** The following sections of this specification are proposed to be updated to normative in the next release:
 > 
-> * [Literals - Long](#long)
-> * [Conversions - toLong](#tolong--long)
 > * [Functions - String (trim, split, join)](#trim--string)
 > * [Functions - Math (except for round)](#math)
 > * [Functions - Utility (precision)](#precision--integer)
@@ -33,6 +31,8 @@ FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions 
 
 > **Note:** The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):
 > 
+> * [Literals - Long](#long)
+> * [Conversions - toLong](#tolong--long)
 > * [Functions - String (lastIndexOf)](#lastindexofsubstring--string--integer)
 > * [Functions - String (matchesFull)](#matchesfullregex--string--boolean)
 > * [Functions - String (encode, decode, escape, unescape)](#additional-string-functions)
@@ -259,20 +259,20 @@ The `Integer` type represents whole numbers in the range -2<sup>31</sup> to 2<su
 > Note that the minus sign (`-`) in the representation of a negative integer is not part of the literal, it is the unary negation operator defined as part of FHIRPath syntax.
 
 ##### Long
-> **Note:** although this section is recent, it has not encountered any edge cases and support has been widely accepted. It is proposed to be normative in the next release.
-{: .stu-note.normative }
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
 
 The `Long` type represents whole numbers in the range -2<sup>63</sup> to 2<sup>63</sup>-1.
-{:.stu.normative}
+{:.stu}
 ``` fhirpath
 0L
 45L
 -5L
 ```
-{:.stu.normative}
+{:.stu}
 
 This type corresponds to System.Long
-{:.stu.normative}
+{:.stu}
 
 #### Decimal
 
@@ -822,21 +822,18 @@ In the above expression, the addition operator expects either two Integers, or t
 
 The following table lists the possible conversions supported, and whether the conversion is implicit or explicit:
 
-|From\To |Boolean |Integer |Long *(STU)*{:.stu-bg.normative} |Decimal |Quantity |String |Date |DateTime |Time |
+|From\To |Boolean |Integer |Long *(STU)*{:.stu-bg} |Decimal |Quantity |String |Date |DateTime |Time |
 |- |- |- |- |- |- |- |- |- | - |
-|**Boolean** |N/A |Explicit | *Explicit*{:.stu-bg.normative} |Explicit |- |Explicit |- |- |- |
-|**Integer** |Explicit |N/A | *Implicit*{:.stu-bg.normative} |Implicit |Implicit |Explicit |- |- |- |
-|**Long** *(STU)*{:.stu-bg.normative} |*Explicit*{:.stu-bg.normative} |*Explicit*{:.stu-bg.normative} | *N/A*{:.stu-bg.normative} |*Implicit*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |*Explicit*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |
-|**Decimal** |Explicit |- | *-*{:.stu-bg.normative} |N/A |Implicit |Explicit |- |- |- |
-|**Quantity** |- |- | *-*{:.stu-bg.normative} |- |N/A |Explicit |- |- |- |
-|**String** |Explicit |Explicit | *Explicit*{:.stu-bg.normative} |Explicit |Explicit |N/A |Explicit |Explicit |Explicit |
-|**Date** |- |- | *-*{:.stu-bg.normative} |- |- |Explicit |N/A |Implicit |- |
-|**DateTime** |- |- | *-*{:.stu-bg.normative} |- |- |Explicit |Explicit |N/A |- |
-|**Time** |- |- | *-*{:.stu-bg.normative} |- |- |Explicit |- |- |N/A |
+|**Boolean** |N/A |Explicit | *Explicit*{:.stu-bg} |Explicit |- |Explicit |- |- |- |
+|**Integer** |Explicit |N/A | *Implicit*{:.stu-bg} |Implicit |Implicit |Explicit |- |- |- |
+|**Long** *(STU)*{:.stu-bg} |*Explicit*{:.stu-bg} |*Explicit*{:.stu-bg} | *N/A*{:.stu-bg} |*Implicit*{:.stu-bg} |*-*{:.stu-bg} |*Explicit*{:.stu-bg} |*-*{:.stu-bg} |*-*{:.stu-bg} |*-*{:.stu-bg} |
+|**Decimal** |Explicit |- | *-*{:.stu-bg} |N/A |Implicit |Explicit |- |- |- |
+|**Quantity** |- |- | *-*{:.stu-bg} |- |N/A |Explicit |- |- |- |
+|**String** |Explicit |Explicit | *Explicit*{:.stu-bg} |Explicit |Explicit |N/A |Explicit |Explicit |Explicit |
+|**Date** |- |- | *-*{:.stu-bg} |- |- |Explicit |N/A |Implicit |- |
+|**DateTime** |- |- | *-*{:.stu-bg} |- |- |Explicit |Explicit |N/A |- |
+|**Time** |- |- | *-*{:.stu-bg} |- |- |Explicit |- |- |N/A |
 {: .grid}
-
- ***Note:*** *The `Long` datatype conversions are proposed to be normative in the next release*
-{:.stu.normative}
 
 * Implicit - Values of the type in the From column will be implicitly converted to values of the type in the To column when necessary
 * Explicit - Values of the type in the From column can be explicitly converted using a function defined in this section
@@ -939,47 +936,47 @@ If the input collection contains multiple items, the evaluation of the expressio
 If the input collection is empty, the result is empty.
 
 ##### toLong() : Long
-> **Note:** the contents of this section are proposed to be updated to normative in the next release
-{: .stu-note.normative }
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
 
 If the input collection contains a single item, this function will return a single integer if:
-{:.stu.normative}
+{:.stu}
 * the item is an Integer or Long
 * the item is a String and is convertible to a 64 bit integer
 * the item is a Boolean, where `true` results in a 1 and `false` results in a 0.
-{:.stu.normative}
+{:.stu}
 
 If the item is not one the above types, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the item is a String, but the string is not convertible to a 64 bit integer (using the regex format `(\+|-)?\d+`), the result is empty.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 ##### convertsToLong() : Boolean
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains a single item, this function will return true if:
-{:.stu.normative}
+{:.stu}
 
 * the item is an Integer or Long
 * the item is a String and is convertible to a Long
 * the item is a Boolean
-{:.stu.normative}
+{:.stu}
 
 If the item is not one of the above types, or the item is a String, but is not convertible to an Integer (using the regex format `(\+|-)?\d+`), the result is false.
-{:.stu.normative}
+{:.stu}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu.normative}
+{:.stu}
 
 If the input collection is empty, the result is empty.
-{:.stu.normative}
+{:.stu}
 
 #### Date Conversion Functions
 

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -3280,7 +3280,7 @@ Get the value of the first component in the first repeat of PID-3
 Message.segment[2].elements(3).simple()
 ```
 
-Get a collection  with is the string values of all the repeats in the the 3rd element of the 2nd segment. Typically, this assumes that there is no repeats, and so this is a simple value
+Get a collection  with is the string values of all the repeats in the 3rd element of the 2nd segment. Typically, this assumes that there are no repeats, and so this is a simple value.
 
 ``` fhirpath
 Message.segment.where(code = 'PID').field[3].element.where(component[4].value = 'MR').simple()

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -33,6 +33,7 @@ FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions 
 
 > **Note:** The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):
 > 
+> * [Functions - String (lastIndexOf)](#lastindexofsubstring--string--integer)
 > * [Functions - String (matchesFull)](#matchesfullregex--string--boolean)
 > * [Functions - String (encode, decode, escape, unescape)](#additional-string-functions)
 > * [Functions - Math (round - due to edge cases)](#roundprecision--integer--decimal)
@@ -1262,6 +1263,31 @@ If the input collection contains multiple items, the evaluation of the expressio
 'abcdefg'.indexOf('x') // -1
 'abcdefg'.indexOf('abcdefg') // 0
 ```
+
+#### lastIndexOf(substring : String) : Integer
+
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
+
+Returns the 0-based index of the last position `substring` is found in the input string, or -1 if it is not found.
+{:.stu}
+
+If `substring` is an empty string (`''`), the function returns 0.
+{:.stu}
+
+If the input or `substring` is empty (`{ }`), the result is empty (`{ }`).
+{:.stu}
+
+If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+{:.stu}
+
+``` fhirpath
+'abcdefg'.lastIndexOf('bc') // 1
+'abcdefg'.lastIndexOf('x') // -1
+'abcdefg'.lastIndexOf('abcdefg') // 0
+'abc abc'.lastIndexOf('a') // 4
+```
+{:.stu}
 
 #### substring(start : Integer [, length : Integer]) : String
 

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -27,6 +27,8 @@ FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions 
 > * [Functions - Math (except for round)](#math)
 > * [Functions - Utility (precision)](#precision--integer)
 > * [Aggregates](#aggregates)
+>
+> ***Note:*** *The green markings are for highlight only during ballot, they will be removed when the balloted content is approved as normative. The stu markings will remain*
 {: .stu-note.normative }
 
 > **Note:** The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -33,6 +33,7 @@ FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions 
 
 > **Note:** The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):
 > 
+> * [Functions - String (matchesFull)](#matchesfullregex--string--boolean)
 > * [Functions - String (encode, decode, escape, unescape)](#additional-string-functions)
 > * [Functions - Math (round - due to edge cases)](#roundprecision--integer--decimal)
 > * [Functions - Utility (defineVariable, lowBoundary, highBoundary)](#definevariable)
@@ -1383,6 +1384,29 @@ If the input collection contains multiple items, the evaluation of the expressio
 'N8000123123'.matches('^N[0-9]{8}$') // returns false as the string is not an 8 char number (it has 10)
 'N8000123123'.matches('N[0-9]{8}') // returns true as the string has an 8 number sequence in it starting with `N`
 ```
+
+#### matchesFull(regex : String) : Boolean
+
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+{: .stu-note }
+
+Returns `true` when the value completely matches the given regular expression (implying that the start/end of line markers `^`, `$` are always surrounding the regex expression provided).
+{:.stu}
+Regular expressions should function consistently, regardless of any culture- and locale-specific settings in the environment, should be case-sensitive, use 'single line' mode and allow Unicode characters.
+{:.stu}
+
+If the input collection or `regex` are empty, the result is empty (`{ }`).
+{:.stu}
+
+If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+{:.stu}
+
+``` fhirpath
+'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('Library') // returns false
+'N8000123123'.matchesFull('N[0-9]{8}') // returns false as the string is not an 8 char number (it has 10)
+'N8000123123'.matchesFull('N[0-9]{10}') // returns true as the string has an 10 number sequence in it starting with `N`
+```
+{:.stu}
 
 #### replaceMatches(regex : String, substitution: String) : String
 

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -1299,13 +1299,20 @@ If the input or `start` is empty, the result is empty.
 
 If an empty `length` is provided, the behavior is the same as if `length` had not been provided.
 
+If a negative or zero `length` is provided, the function returns an empty string (`''`).
+
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
 
 ``` fhirpath
 'abcdefg'.substring(3) // 'defg'
 'abcdefg'.substring(1, 2) // 'bc'
 'abcdefg'.substring(6, 2) // 'g'
-'abcdefg'.substring(7, 1) // { }
+'abcdefg'.substring(7, 1) // { } (start position is outside the string)
+'abcdefg'.substring(-1, 1) // { } (start position is outside the string,
+                           //     this can happen when the -1 was the result of a calculation rather than explicitly provided)
+'abcdefg'.substring(3, 0) // '' (empty string)
+'abcdefg'.substring(3, -1) // '' (empty string)
+'abcdefg'.substring(-1, -1) // {} (start position is outside the string)
 ```
 
 #### startsWith(prefix : String) : Boolean

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -6,7 +6,7 @@ standards-status: normative
 
 FHIRPath is a path based navigation and extraction language, somewhat like XPath. Operations are expressed in terms of the logical content of hierarchical data models, and support traversal, selection and filtering of data. Its design was influenced by the needs for path navigation, selection and formulation of invariants in both HL7 Fast Healthcare Interoperability Resources ([FHIR](http://hl7.org/fhir)) and HL7 Clinical Quality Language ([CQL](http://cql.hl7.org/03-developersguide.html#using-fhirpath)).
 
-Looking for implementations? See [FHIRPath Implementations on the HL7 wiki](http://wiki.hl7.org/index.php?title=FHIRPath_Implementations)
+Looking for implementations? See [FHIRPath Implementations on the HL7 confluence](https://confluence.hl7.org/display/FHIRI/FHIRPath+Implementations){:target="_blank"}
 
 Version: 2.0.0 Public Domain ([Creative Commons 0](http://creativecommons.org/publicdomain/zero/1.0/))
 
@@ -3251,41 +3251,21 @@ Note that if the parser cannot properly parse the Abstract Message Syntax, group
 ## FHIRPath Tooling and Implementation
 {: .appendix }
 
-This section lists known tooling and implementation projects for the FHIRPath language:
+The list of known tooling and implementation projects for the FHIRPath language has been moved to the [HL7 confluence site](https://confluence.hl7.org/display/FHIRI/FHIRPath+Implementations){:target="_blank"}
 
-* JavaScript: https://github.com/HL7/fhirpath.js/
-* Java RI: In the FHIR build tooling at org.hl7.fhir.dstu3.utils.FHIRPathEngine
-* Pascal RI: https://github.com/grahamegrieve/fhirserver/blob/master/library/r3/FHIR.R3.PathEngine.pas
-* .NET RI: https://github.com/ewoutkramer/fhir-net-fhirpath
-
-In addition, there is a Notepad++ FHIR Plugin that enables evaluation of FHIRPath expressions:
-
-http://www.healthintersections.com.au/?p=2386
-
-There is a test harness for FHIRPath here:
-
-https://github.com/brianpos/FhirPathTester
-
-The CQL-to-ELM translator that is maintained as part of the tooling for Clinical Quality Language supports FHIRPath:
-
-https://github.com/cqframework/clinical_quality_language
-
-For the most current listing of known implementations, refer to the HL7 wiki:
-
-http://wiki.hl7.org/index.php?title=FHIRPath_Implementations
 
 ## References
 {: .appendix }
 
 <a name="bibliography"></a>
-- <a name="ANTLR"></a>[ANTLR] Another Tool for Language Recognition (ANTLR) <http://www.antlr.org/>
-- <a name="ISO8601"></a>[ISO8601] Date and time format - ISO 8601. <https://www.iso.org/iso-8601-date-and-time-format.html>
-- <a name="CQL"></a>[CQL] HL7 Cross-Paradigm Specification: Clinical Quality Language, Release 1, STU Release 1.3. <http://www.hl7.org/implement/standards/product_brief.cfm?product_id=400>
-- <a name="MOF"></a>[MOF] Meta Object Facility. <https://www.omg.org/spec/MOF/>, version 2.5.1, November 2016
-- <a name="XMLRE"></a>[XMLRE] Regular Expressions. XML Schema 1.1. <https://www.w3.org/TR/xmlschema11-2/#regexs>
-- <a name="PCRE"></a>[PCRE] Pearl-Compatible Regular Expressions. <http://www.pcre.org/>
-- <a name="UCUM"></a>[UCUM] Unified Code for Units of Measure (UCUM) <http://unitsofmeasure.org/ucum.html>, Version 2.1, Revision 442 (2017-11-21)
-- <a name="FHIR"></a>[FHIR] HL7 Fast Healthcare Interoperability Resources <http://hl7.org/fhir>
+- <a name="ANTLR"></a>[ANTLR] Another Tool for Language Recognition (ANTLR) <http://www.antlr.org/>{:target="_blank"}
+- <a name="ISO8601"></a>[ISO8601] Date and time format - ISO 8601. <https://www.iso.org/iso-8601-date-and-time-format.html>{:target="_blank"}
+- <a name="CQL"></a>[CQL] HL7 Cross-Paradigm Specification: Clinical Quality Language, Release 1, STU Release 1.3. <http://www.hl7.org/implement/standards/product_brief.cfm?product_id=400>{:target="_blank"}
+- <a name="MOF"></a>[MOF] Meta Object Facility. <https://www.omg.org/spec/MOF/>{:target="_blank"}, version 2.5.1, November 2016
+- <a name="XMLRE"></a>[XMLRE] Regular Expressions. XML Schema 1.1. <https://www.w3.org/TR/xmlschema11-2/#regexs>{:target="_blank"}
+- <a name="PCRE"></a>[PCRE] Pearl-Compatible Regular Expressions. <http://www.pcre.org/>{:target="_blank"}
+- <a name="UCUM"></a>[UCUM] Unified Code for Units of Measure (UCUM) <http://unitsofmeasure.org/ucum.html>{:target="_blank"}, Version 2.1, Revision 442 (2017-11-21)
+- <a name="FHIR"></a>[FHIR] HL7 Fast Healthcare Interoperability Resources <http://hl7.org/fhir>{:target="_blank"}
 - [grammar.html](grammar.html)
 - [modelinfo.xsd](modelinfo.xsd)
-- <a name="fluent"></a>[Fluent] Fluent interface pattern. <https://en.wikipedia.org/wiki/Fluent_interface>
+- <a name="fluent"></a>[Fluent] Fluent interface pattern. <https://en.wikipedia.org/wiki/Fluent_interface>{:target="_blank"}

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -21,16 +21,23 @@ Version: 2.0.0 Public Domain ([Creative Commons 0](http://creativecommons.org/pu
 FHIRPath is an ANSI Normative Standard. ANSI has certificated that the portions of this specification marked Normative have met its requirements for development of a formal standard.
 
 
-> Note: The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):
+> **Note:** The following sections of this specification are proposed to be updated to normative in the next release:
 > 
 > * [Literals - Long](#long)
 > * [Conversions - toLong](#tolong--long)
-> * [Functions - String (additional functions, marked as appropriate)](#additional-string-functions)
-> * [Functions - Math](#math)
-> * [Functions - Utility defineVariable, lowBoundary, highBoundary, precision](#definevariable)
+> * [Functions - String (trim, split, join)](#trim--string)
+> * [Functions - Math (except for round)](#math)
+> * [Functions - Utility (precision)](#precision--integer)
+> * [Aggregates](#aggregates)
+{: .stu-note.normative }
+
+> **Note:** The following sections of this specification have not received significant implementation experience and are marked for Standard for Trial Use (STU):
+> 
+> * [Functions - String (encode, decode, escape, unescape)](#additional-string-functions)
+> * [Functions - Math (round - due to edge cases)](#roundprecision--integer--decimal)
+> * [Functions - Utility (defineVariable, lowBoundary, highBoundary)](#definevariable)
 > * [Functions - Extract Date/DateTime/Time components](#extract-datedatetimetime-components)
 > * [Types - Reflection](#reflection)
-> * [Aggregates](#aggregates)
 > 
 > In addition, the appendices are included as additional documentation and are informative content.
 {: .stu-note }
@@ -250,20 +257,20 @@ The `Integer` type represents whole numbers in the range -2<sup>31</sup> to 2<su
 > Note that the minus sign (`-`) in the representation of a negative integer is not part of the literal, it is the unary negation operator defined as part of FHIRPath syntax.
 
 ##### Long
-> Note: the contents of this section are Standard for Trial Use (STU)
-{: .stu-note }
+> **Note:** although this section is recent, it has not encountered any edge cases and support has been widely accepted. It is proposed to be normative in the next release.
+{: .stu-note.normative }
 
 The `Long` type represents whole numbers in the range -2<sup>63</sup> to 2<sup>63</sup>-1.
-{:.stu}
+{:.stu.normative}
 ``` fhirpath
 0L
 45L
 -5L
 ```
-{:.stu}
+{:.stu.normative}
 
 This type corresponds to System.Long
-{:.stu}
+{:.stu.normative}
 
 #### Decimal
 
@@ -813,18 +820,21 @@ In the above expression, the addition operator expects either two Integers, or t
 
 The following table lists the possible conversions supported, and whether the conversion is implicit or explicit:
 
-|From\To |Boolean |Integer |Long *(STU)*{:.stu-bg} |Decimal |Quantity |String |Date |DateTime |Time |
+|From\To |Boolean |Integer |Long *(STU)*{:.stu-bg.normative} |Decimal |Quantity |String |Date |DateTime |Time |
 |- |- |- |- |- |- |- |- |- | - |
-|**Boolean** |N/A |Explicit | *Explicit*{:.stu-bg} |Explicit |- |Explicit |- |- |- |
-|**Integer** |Explicit |N/A | *Implicit*{:.stu-bg} |Implicit |Implicit |Explicit |- |- |- |
-|**Long** *(STU)*{:.stu-bg} |*Explicit*{:.stu-bg} |*Explicit*{:.stu-bg} | *N/A*{:.stu-bg} |*Implicit*{:.stu-bg} |*-*{:.stu-bg} |*Explicit*{:.stu-bg} |*-*{:.stu-bg} |*-*{:.stu-bg} |*-*{:.stu-bg} |
-|**Decimal** |Explicit |- | *-*{:.stu-bg} |N/A |Implicit |Explicit |- |- |- |
-|**Quantity** |- |- | *-*{:.stu-bg} |- |N/A |Explicit |- |- |- |
-|**String** |Explicit |Explicit | *Explicit*{:.stu-bg} |Explicit |Explicit |N/A |Explicit |Explicit |Explicit |
-|**Date** |- |- | *-*{:.stu-bg} |- |- |Explicit |N/A |Implicit |- |
-|**DateTime** |- |- | *-*{:.stu-bg} |- |- |Explicit |Explicit |N/A |- |
-|**Time** |- |- | *-*{:.stu-bg} |- |- |Explicit |- |- |N/A |
+|**Boolean** |N/A |Explicit | *Explicit*{:.stu-bg.normative} |Explicit |- |Explicit |- |- |- |
+|**Integer** |Explicit |N/A | *Implicit*{:.stu-bg.normative} |Implicit |Implicit |Explicit |- |- |- |
+|**Long** *(STU)*{:.stu-bg.normative} |*Explicit*{:.stu-bg.normative} |*Explicit*{:.stu-bg.normative} | *N/A*{:.stu-bg.normative} |*Implicit*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |*Explicit*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |*-*{:.stu-bg.normative} |
+|**Decimal** |Explicit |- | *-*{:.stu-bg.normative} |N/A |Implicit |Explicit |- |- |- |
+|**Quantity** |- |- | *-*{:.stu-bg.normative} |- |N/A |Explicit |- |- |- |
+|**String** |Explicit |Explicit | *Explicit*{:.stu-bg.normative} |Explicit |Explicit |N/A |Explicit |Explicit |Explicit |
+|**Date** |- |- | *-*{:.stu-bg.normative} |- |- |Explicit |N/A |Implicit |- |
+|**DateTime** |- |- | *-*{:.stu-bg.normative} |- |- |Explicit |Explicit |N/A |- |
+|**Time** |- |- | *-*{:.stu-bg.normative} |- |- |Explicit |- |- |N/A |
 {: .grid}
+
+ ***Note:*** *The `Long` datatype conversions are proposed to be normative in the next release*
+{:.stu.normative}
 
 * Implicit - Values of the type in the From column will be implicitly converted to values of the type in the To column when necessary
 * Explicit - Values of the type in the From column can be explicitly converted using a function defined in this section
@@ -927,47 +937,47 @@ If the input collection contains multiple items, the evaluation of the expressio
 If the input collection is empty, the result is empty.
 
 ##### toLong() : Long
-> Note: the contents of this section are Standard for Trial Use (STU)
-{: .stu-note }
+> **Note:** the contents of this section are proposed to be updated to normative in the next release
+{: .stu-note.normative }
 
 If the input collection contains a single item, this function will return a single integer if:
-{:.stu}
+{:.stu.normative}
 * the item is an Integer or Long
 * the item is a String and is convertible to a 64 bit integer
 * the item is a Boolean, where `true` results in a 1 and `false` results in a 0.
-{:.stu}
+{:.stu.normative}
 
 If the item is not one the above types, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the item is a String, but the string is not convertible to a 64 bit integer (using the regex format `(\+|-)?\d+`), the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 ##### convertsToLong() : Boolean
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains a single item, this function will return true if:
-{:.stu}
+{:.stu.normative}
 
 * the item is an Integer or Long
 * the item is a String and is convertible to a Long
 * the item is a Boolean
-{:.stu}
+{:.stu.normative}
 
 If the item is not one of the above types, or the item is a String, but is not convertible to an Integer (using the regex format `(\+|-)?\d+`), the result is false.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 #### Date Conversion Functions
 
@@ -1477,226 +1487,231 @@ If no target is specified, the result is empty.
 {:.stu}
 
 #### trim() : String
-{:.stu}
+> **Note:** the contents of this section are proposed to be updated to normative in the next release
+{: .stu-note.normative }
 
 The trim function trims whitespace characters from the beginning and ending of the input string, with whitespace characters as defined in the [Whitespace](#whitespace) lexical category.
-{:.stu}
+{:.stu.normative}
 
 If the input is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 #### split(separator: String) : collection
-{:.stu}
+{:.stu.normative}
 
 The split function splits a singleton input string into a list of strings, using the given separator.
-{:.stu}
+{:.stu.normative}
 
 If the input is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input string does not contain any appearances of the separator, the result is the input string.
-{:.stu}
+{:.stu.normative}
 
 The following example illustrates the behavior of the `.split` operator:
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 ('A,B,C').split(',') // { 'A', 'B', 'C' }
 ('ABC').split(',') // { 'ABC' }
 'A,,C'.split(',') // { 'A', '', 'C' }
 ```
-{:.stu}
+{:.stu.normative}
 
 #### join([separator: String]) : String
-{:.stu}
+{:.stu.normative}
 
 The join function takes a collection of strings and _joins_ them into a single string, optionally using the given separator.
-{:.stu}
+{:.stu.normative}
 
 If the input is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If no separator is specified, the strings are directly concatenated.
-{:.stu}
+{:.stu.normative}
 
 The following example illustrates the behavior of the `.join` operator:
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 ('A' | 'B' | 'C').join() // 'ABC'
 ('A' | 'B' | 'C').join(',') // 'A,B,C'
 ```
-{:.stu}
+{:.stu.normative}
 
 ### Math
 
-> Note: the contents of this section are Standard for Trial Use (STU)
-{: .stu-note }
+> **Note:** the contents of this section are proposed to be updated to normative in the next release
+{: .stu-note.normative }
 
 The functions in this section operate on collections with a single item. Unless otherwise noted, if there is more than one item, or the item is not compatible with the expected type, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 Note also that although all functions return collections, if a given function is defined to return a single element, the return type in the description of the function is simplified to just the type of the single element, rather than the list type.
-{:.stu}
+{:.stu.normative}
 
 The math functions in this section enable FHIRPath to be used not only for path selection, but for providing a platform-independent representation of calculation logic in artifacts such as questionnaires and documentation templates. For example:
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 (%weight/(%height.power(2))).round(1)
 ```
-{:.stu}
+{:.stu.normative}
 
 This example from a questionnaire calculates the Body Mass Index (BMI) based on the responses to the weight and height elements. For more information on the use of FHIRPath in questionnaires, see the [Structured Data Capture](http://hl7.org/fhir/uv/sdc/) (SDC) implementation guide.
-{:.stu}
+{:.stu.normative}
 
 #### abs() : Integer | Decimal | Quantity
-{:.stu}
+{:.stu.normative}
 
 Returns the absolute value of the input. When taking the absolute value of a quantity, the unit is unchanged.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 (-5).abs() // 5
 (-5.5).abs() // 5.5
 (-5.5 'mg').abs() // 5.5 'mg'
 ```
-{:.stu}
+{:.stu.normative}
 
 #### ceiling() : Integer
-{:.stu}
+{:.stu.normative}
 
 Returns the first integer greater than or equal to the input.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 1.ceiling() // 1
 1.1.ceiling() // 2
 (-1.1).ceiling() // -1
 ```
-{:.stu}
+{:.stu.normative}
 
 #### exp() : Decimal
-{:.stu}
+{:.stu.normative}
 
 Returns _e_ raised to the power of the input.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains an Integer, it will be implicitly converted to a Decimal and the result will be a Decimal.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 0.exp() // 1.0
 (-0.0).exp() // 1.0
 ```
-{:.stu}
+{:.stu.normative}
 
 #### floor() : Integer
-{:.stu}
+{:.stu.normative}
 
 Returns the first integer less than or equal to the input.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 1.floor() // 1
 2.1.floor() // 2
 (-2.1).floor() // -3
 ```
-{:.stu}
+{:.stu.normative}
 
 #### ln() : Decimal
-{:.stu}
+{:.stu.normative}
 
 Returns the natural logarithm of the input (i.e. the logarithm base _e_).
-{:.stu}
+{:.stu.normative}
 
 When used with an Integer, it will be implicitly converted to a Decimal.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 1.ln() // 0.0
 1.0.ln() // 0.0
 ```
-{:.stu}
+{:.stu.normative}
 
 #### log(base : Decimal) : Decimal
-{:.stu}
+{:.stu.normative}
 
 Returns the logarithm base `base` of the input number.
-{:.stu}
+{:.stu.normative}
 
 When used with Integers, the arguments will be implicitly converted to Decimal.
-{:.stu}
+{:.stu.normative}
 
 If `base` is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 16.log(2) // 4.0
 100.0.log(10.0) // 2.0
 ```
-{:.stu}
+{:.stu.normative}
 
 #### power(exponent : Integer | Decimal) : Integer | Decimal
-{:.stu}
+{:.stu.normative}
 
 Raises a number to the `exponent` power. If this function is used with Integers, the result is an Integer. If the function is used with Decimals, the result is a Decimal. If the function is used with a mixture of Integer and Decimal, the Integer is implicitly converted to a Decimal and the result is a Decimal.
-{:.stu}
+{:.stu.normative}
 
 If the power cannot be represented (such as the -1 raised to the 0.5), the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input is empty, or exponent is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 2.power(3) // 8
 2.5.power(2) // 6.25
 (-1).power(0.5) // empty ({ })
 ```
-{:.stu}
+{:.stu.normative}
 
 #### round([precision : Integer]) : Decimal
-{:.stu}
+
+> **Note:** The contents of this section are Standard for Trial Use (STU)
+>
+> [Discussion on this topic](https://chat.fhir.org/#narrow/stream/179266-fhirpath/topic/round.28.29.20for.20negative.20numbers) If you have specific proposals or feedback please log a change request.
+{: .stu-note }
 
 Rounds the decimal to the nearest whole number using a traditional round (i.e. 0.5 or higher will round to 1). If specified, the precision argument determines the decimal place at which the rounding will occur. If not specified, the rounding will default to 0 decimal places.
 {:.stu}
@@ -1720,47 +1735,49 @@ If the input collection contains multiple items, the evaluation of the expressio
 {:.stu}
 
 #### sqrt() : Decimal
-{:.stu}
+
+> **Note:** the contents of this section are proposed to be updated to normative in the next release
+{: .stu-note.normative }
 
 Returns the square root of the input number as a Decimal.
-{:.stu}
+{:.stu.normative}
 
 If the square root cannot be represented (such as the square root of -1), the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 81.sqrt() // 9.0
 (-1).sqrt() // empty
 ```
-{:.stu}
+{:.stu.normative}
 
 #### truncate() : Integer
-{:.stu}
+{:.stu.normative}
 
 Returns the integer portion of the input.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 101.truncate() // 101
 1.00000001.truncate() // 1
 (-1.56).truncate() // -1
 ```
-{:.stu}
+{:.stu.normative}
 
 ### Tree navigation
 
@@ -1899,30 +1916,32 @@ If the input collection contains multiple items, the evaluation of the expressio
 {:.stu}
 
 #### precision() : Integer
-{:.stu}
+
+> **Note:** the contents of this section are proposed to be updated to normative in the next release
+{: .stu-note.normative }
 
 If the input collection contains a single item, this function will return the number of digits of precision.
-{:.stu}
+{:.stu.normative}
 
 The function can only be used with Decimal, Date, DateTime, and Time values.
-{:.stu}
+{:.stu.normative}
 
 If the input collection is empty, the result is empty.
-{:.stu}
+{:.stu.normative}
 
 If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-{:.stu}
+{:.stu.normative}
 
 For Decimal values, the function returns the number of digits of precision after the decimal place in the input value.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 1.58700.precision() // 5
 ```
-{:.stu}
+{:.stu.normative}
 
 For Date and DateTime values, the function returns the number of digits of precision in the input value.
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 @2014.precision() // 4
@@ -1930,7 +1949,7 @@ For Date and DateTime values, the function returns the number of digits of preci
 @T10:30.precision() // 4
 @T10:30:00.000.precision() // 9
 ```
-{:.stu}
+{:.stu.normative}
 
 #### Extract Date/DateTime/Time components
 > **Note:** The contents of this section are Standard for Trial Use (STU)
@@ -2725,44 +2744,44 @@ Use parentheses to ensure the unary negation applies to the `7`:
 
 ## Aggregates
 
-> Note: the contents of this section are Standard for Trial Use (STU)
-{: .stu-note }
+> **Note:** the contents of this section are proposed to be updated to normative in the next release
+{: .stu-note.normative }
 
 FHIRPath supports a general-purpose aggregate function to enable the calculation of aggregates such as sum, min, and max to be expressed:
-{:.stu}
+{:.stu.normative}
 
 ### aggregate(aggregator : expression [, init : value]) : value
-{:.stu}
+{:.stu.normative}
 Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Within this expression, the standard iteration variables of `$this` and `$index` can be accessed, but also a `$total` aggregation variable.
-{:.stu}
+{:.stu.normative}
 
 The value of the `$total` variable is set to `init`, or empty (`{ }`) if no `init` value is supplied, and is set to the result of the aggregator expression after every iteration.<br/>
 The result of the aggregate function is the value of `$total` after the last iteration.
-{:.stu}
+{:.stu.normative}
 
 Using this function, sum can be expressed as:
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 value.aggregate($this + $total, 0)
 ```
-{:.stu}
+{:.stu.normative}
 
 Min can be expressed as:
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 value.aggregate(iif($total.empty(), $this, iif($this < $total, $this, $total)))
 ```
-{:.stu}
+{:.stu.normative}
 
 and average would be expressed as:
-{:.stu}
+{:.stu.normative}
 
 ``` fhirpath
 value.aggregate($total + $this, 0) / value.count()
 ```
-{:.stu}
+{:.stu.normative}
 
 ## Lexical Elements
 FHIRPath defines the following lexical elements:

--- a/template-fhirpath/content/assets/css/fhirpath.css
+++ b/template-fhirpath/content/assets/css/fhirpath.css
@@ -195,3 +195,9 @@ h6.appendix:before {
     counter-increment: more-detail;
     content: "Appendix " counter(appendix, upper-alpha) "." counter(sub-section) "." counter(composite) "." counter(detail) "." counter(more-detail) ": ";
 }
+
+/* override the fhir label formatting inside the ANTLR code formatted block */
+.language-antlr4 .token.label {
+    font-size: unset;
+    background-color: unset;
+}

--- a/template-fhirpath/content/assets/css/fhirpath.css
+++ b/template-fhirpath/content/assets/css/fhirpath.css
@@ -12,6 +12,39 @@ blockquote.trialuse {
     background-color: #e7f3fe;
 }
 
+.stu-note.normative::before {
+    content: "Proposed Normative Content\A ";
+    display: flex;
+    padding: 4px 0;
+    margin-bottom: 4px;
+    background-color: unset;
+}
+
+.stu-note::before {
+    display: flex;
+    padding: 4px;
+    margin-bottom: 4px;
+}
+
+.stu-note.normative {
+    border-left-color: green;
+    background-color: #e0ffe0;
+}
+
+.stu.normative:after {
+    border-left-color: green;
+}
+
+.stu-bg.normative {
+    background-color: #e0ffe0;
+}
+
+table.grid th:has(.stu-bg.normative),
+th:has(.stu-bg.normative),
+td:has(.stu-bg.normative) {
+    background-color: #e0ffe0;
+}
+
 .stu {
     /* border-left: 5px solid #2196F3;
     background-color: #e7f3fe;*/
@@ -36,7 +69,7 @@ pre.language-fhirpath.stu {
     overflow: unset;
 }
 pre.language-fhirpath.stu:after {
-    left: -15.5px;
+    left: -16px;
 }
 
 table.stu {
@@ -54,7 +87,7 @@ blockquote.stu {
 }
 
 blockquote.stu:after {
-    left: -19.5px;
+    left: -20px;
 }
 
 blockquote.stu:before {

--- a/template-fhirpath/content/assets/css/fhirpath.css
+++ b/template-fhirpath/content/assets/css/fhirpath.css
@@ -28,11 +28,13 @@ blockquote.trialuse {
 
 .stu-note.normative {
     border-left-color: green;
+    border-left-style: double;
     background-color: #e0ffe0;
 }
 
 .stu.normative:after {
     border-left-color: green;
+    border-left-style: double;
 }
 
 .stu-bg.normative {
@@ -200,4 +202,25 @@ h6.appendix:before {
 .language-antlr4 .token.label {
     font-size: unset;
     background-color: unset;
+}
+
+/* Accessibility tweaks */
+:root {
+    --link-color: #3470a2; /* 13. Hyperlink text color */
+    --toc-box-bg-color: #ffff8a; /* 14. Table of Contents box background color */
+    --footer-hyperlink-text-color: #94daff; /* 15. Footer hyperlink text color */
+}
+        
+a {
+    font-weight: 500;
+}
+
+code.language-typescript, code.language-regex, code.language-txt {
+    white-space: pre-wrap;
+    overflow: unset;
+    word-break: break-word;
+}
+
+.language-antlr4 .token.punctuation {
+    color: #6e6e6e;
 }

--- a/template-fhirpath/content/assets/css/prism-fhirpath.css
+++ b/template-fhirpath/content/assets/css/prism-fhirpath.css
@@ -23,7 +23,7 @@ pre.language-fhirpath.stu {
     overflow: unset;
 }
 pre.language-fhirpath.stu:after {
-    left: -15.5px;
+    left: -16px;
 }
 
 /* inline fhirpath code blocks used in examples */

--- a/template-fhirpath/content/assets/css/prism-fhirpath.css
+++ b/template-fhirpath/content/assets/css/prism-fhirpath.css
@@ -1,12 +1,14 @@
 /* Custom formatting for the code blocks */
 pre.language-fhirpath {
-    background-color: #eee;
+    background-color: #fbfbfb78;
     text-shadow: unset;
 }
 
 pre.language-fhirpath code.language-fhirpath {
     white-space: pre-wrap;
     text-shadow: unset;
+    word-break: break-word;
+    overflow: unset;
 }
 
 .token.operator,
@@ -35,4 +37,31 @@ pre.language-fhirpath.stu:after {
     display: inline-block;
     margin: 2px 0;
     text-shadow: unset;
+}
+
+/* Color changes to improve accessibility */
+.token.atrule, .token.attr-value, .token.keyword
+{
+    color: #0071a1;
+}
+
+.token.selector, .token.attr-name, .token.string, .token.char, .token.builtin, .token.inserted {
+    color: #4c7400;
+}
+
+.token.comment, .token.prolog, .token.doctype, .token.cdata {
+    color: #5f6c7a;
+}
+
+.token.regex, .token.important, .token.variable {
+    color: #925d00;
+    font-weight: bold;
+}
+
+.token.function, .token.class-name {
+    color: #bc3e58;
+}
+
+.language-typescript .nl, .language-typescript .na {
+    color: #006699;
 }

--- a/template-fhirpath/includes/fragment-pagebegin.html
+++ b/template-fhirpath/includes/fragment-pagebegin.html
@@ -77,7 +77,7 @@
         <nav class="navbar navbar-inverse">
           <!--status-bar-->
           <div class="container">
-            <button data-target=".navbar-inverse-collapse" class="navbar-toggle" data-toggle="collapse" type="button">
+            <button data-target=".navbar-inverse-collapse" class="navbar-toggle" data-toggle="collapse" type="button" aria-label="Show navigation menu" title="Show navigation menu">
               <span class="icon-bar"> </span>
               <span class="icon-bar"> </span>
               <span class="icon-bar"> </span>


### PR DESCRIPTION
FHIR-46808 Many obvious typos
FHIR-40620 Move list of Implementations into Confluence
FHIR-40810 Firely reference is stale, however this content is now moved out of the spec to confluence
And make the references links open in a new tab
FHIR-36270 Add matchesFull to support full matching
FHIR-32882 Add `lastIndexOf` function
FHIR-37705 clarify that a negative length argument should be treated as zero in `substring`
FHIR-44803 Spelling errors and typos